### PR TITLE
adding missing isiolation level for snadboxed connections

### DIFF
--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -29,7 +29,7 @@ defmodule DemoMssqlWeb.ChannelCase do
   end
 
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DemoMssql.Repo)
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DemoMssql.Repo, isolation_level: :snapshot)
 
     unless tags[:async] do
       Ecto.Adapters.SQL.Sandbox.mode(DemoMssql.Repo, {:shared, self()})

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -32,7 +32,7 @@ defmodule DemoMssqlWeb.ConnCase do
   end
 
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DemoMssql.Repo)
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DemoMssql.Repo, isolation_level: :snapshot)
 
     unless tags[:async] do
       Ecto.Adapters.SQL.Sandbox.mode(DemoMssql.Repo, {:shared, self()})

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -28,7 +28,7 @@ defmodule DemoMssql.DataCase do
   end
 
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DemoMssql.Repo)
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(DemoMssql.Repo, isolation_level: :snapshot)
 
     unless tags[:async] do
       Ecto.Adapters.SQL.Sandbox.mode(DemoMssql.Repo, {:shared, self()})


### PR DESCRIPTION
This should [fix](https://github.com/elixir-ecto/ecto_sql/issues/221) deadlock issue.

Thing is that even tho database is altered to **ALLOW** snapshots you must be explicit when you want to **USE** snapshot. Since tests are not creating explicit transactions, they are rather created by sandbox, you need to pass `isolation_level: :snapshot` option when you are checking out  repo/connection.